### PR TITLE
support greater range of lockfiles

### DIFF
--- a/test/Gemfile2.lock
+++ b/test/Gemfile2.lock
@@ -1,0 +1,82 @@
+GIT
+  remote: https://github.com/rspec/rspec.git
+  revision: bc209d4a2a2dfbf38ac1d470b213753aa9e654db
+  specs:
+    rspec (3.6.0.beta1)
+      rspec-core (= 3.6.0.beta1)
+      rspec-expectations (= 3.6.0.beta1)
+      rspec-mocks (= 3.6.0.beta1)
+
+GIT
+  remote: https://github.com/sparklemotion/nokogiri.git
+  revision: 7f8b7b2bf55829e02cd11c2eb25814c3ed458676
+  specs:
+    nokogiri (1.0.0)
+
+GEM
+  remote: https://rubygems.org/
+  specs:
+    activemodel (5.0.0.1)
+      activesupport (= 5.0.0.1)
+    activerecord (5.0.0.1)
+      activemodel (= 5.0.0.1)
+      activesupport (= 5.0.0.1)
+      arel (~> 7.0)
+    activesupport (5.0.0.1)
+      concurrent-ruby (~> 1.0, >= 1.0.2)
+      i18n (~> 0.7)
+      minitest (~> 5.1)
+      tzinfo (~> 1.1)
+    arel (7.1.4)
+    concurrent-ruby (1.0.2)
+    diff-lcs (1.2.5)
+    fastreader (1.0.8)
+      activerecord (>= 2.0.0)
+      activesupport (>= 2.0.0)
+      feed-normalizer (>= 1.5.1)
+      highline (>= 1.4.0)
+      hoe (>= 1.6.0)
+      hpricot (>= 0.6)
+      simple-rss (>= 1.1)
+      sqlite3-ruby (>= 1.2.2)
+    feed-normalizer (1.5.2)
+      hpricot (>= 0.6)
+      simple-rss (>= 1.1)
+    highline (1.7.8)
+    hoe (3.15.2)
+      rake (>= 0.8, < 12.0)
+    hpricot (0.8.6)
+    i18n (0.7.0)
+    minitest (5.9.1)
+    pdfkit (0.5.2)
+    rack (1.6.4)
+    rake (11.3.0)
+    rspec-core (3.6.0.beta1)
+      rspec-support (= 3.6.0.beta1)
+    rspec-expectations (3.6.0.beta1)
+      diff-lcs (>= 1.2.0, < 2.0)
+      rspec-support (= 3.6.0.beta1)
+    rspec-mocks (3.6.0.beta1)
+      diff-lcs (>= 1.2.0, < 2.0)
+      rspec-support (= 3.6.0.beta1)
+    rspec-support (3.6.0.beta1)
+    simple-rss (1.3.1)
+    sqlite3 (1.3.12)
+    sqlite3-ruby (1.3.3)
+      sqlite3 (>= 1.3.3)
+    thread_safe (0.3.5)
+    tzinfo (1.2.2)
+      thread_safe (~> 0.1)
+
+PLATFORMS
+  ruby
+
+DEPENDENCIES
+  fastreader
+  nokogiri (= 1.0.0)!
+  pdfkit (~> 0.5)
+  rack (~> 1.1)
+  rspec!
+
+BUNDLED WITH
+   1.13.6

--- a/test/gemfile.test.js
+++ b/test/gemfile.test.js
@@ -42,7 +42,6 @@ describe('gemfile', function() {
 
       it('adjusts "BUNDLED WITH" by changing it to a String indicating version', function() {
         let output = gemfile.interpret(file);
-
         assert.property(output, 'BUNDLED WITH');
         assert.match(output['BUNDLED WITH'], /\d{1,3}\.\d{1,3}\.\d{1,3}/);
       });
@@ -130,6 +129,30 @@ describe('gemfile', function() {
       }).catch(function(error) {
         throw error;
       });
+    });
+  });
+
+  describe('meta analysis', function () {
+    const file = fs.readFileSync('test/Gemfile2.lock', 'utf8');
+    it('outputs an Object with three mandatory keys', function() {
+      let output = gemfile.interpret(file);
+
+      assert.property(output, 'GEM');
+      assert.property(output, 'GIT');
+      assert.property(output, 'DEPENDENCIES');
+      assert.property(output, 'PLATFORMS');
+    });
+
+    it('has a good meta specs', function () {
+      let output = gemfile.interpret(file, true);
+      assert.property(output.specs, 'rspec');
+      assert.property(output.specs, 'nokogiri');
+      assert.property(output.specs, 'activemodel');
+    });
+
+    it('has actual metadata', function () {
+      let output = gemfile.interpret(file, true);
+      assert.property(output.specs.rspec, 'revision');
     });
   });
 });


### PR DESCRIPTION
Hey!
Currently, this module only supports 1 entry each of types GEM, PATH and GIT, so this PR attempts to fix this in 2 ways:

- Creates extra (numbered) keys for the gemfile object (such as `GIT1`), which don't break interface.
- Allows for meta analysis, returning an object with unified specs and metadata.